### PR TITLE
Fix distro name parsing in system info script

### DIFF
--- a/sysinfo/01_basic.sh
+++ b/sysinfo/01_basic.sh
@@ -8,7 +8,7 @@ echo "-----------------------------"
 if command -v lsb_release &>/dev/null; then
     echo "📦  发行版本 : $(lsb_release -ds)"
 else
-    echo "📦  发行版本 : $(cat /etc/os-release | grep PRETTY_NAME | cut -d= -f2 | tr -d \")"
+    echo "📦  发行版本 : $(grep PRETTY_NAME /etc/os-release | cut -d= -f2 | tr -d '"')"
 fi
 
 # 内核版本


### PR DESCRIPTION
## Summary
- improve parsing of distro name

## Testing
- `shellcheck sysinfo/01_basic.sh`
- `find . -name "*.sh" -print0 | xargs -0 shellcheck`
- `bash sysinfo/01_basic.sh`

------
https://chatgpt.com/codex/tasks/task_e_68407877e4208333a1468aaad25d11f2